### PR TITLE
create tmp security key when running locally

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,5 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-WhatsHapp::Application.config.secret_key_base = ENV.fetch('SECRET_TOKEN')
+WhatsHapp::Application.config.secret_key_base = ENV['SECRET_TOKEN'].nil? ? ('x' * 30) : ENV['SECRET_TOKEN']
+


### PR DESCRIPTION
You might like it failing for security's sake...  but this ensures it works when someone first pulls.
